### PR TITLE
fixed math error

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -29,7 +29,7 @@
     
     const g = false; // Is the data transferred from a green host?
   
-    let e = emissions.perByte(b, g).toFixed(3) * 1000; // Convert to grams
+    let e = emissions.perByte(b, g).toFixed(3);
   
     document.getElementById("bytes-transferred").innerHTML = Math.round(b / 1000); // Convert to KB
     document.getElementById("page-co2e").innerHTML = e;


### PR DESCRIPTION
I thought the result of co2.js was in KG but it's already in grams. This fixes the math so our numbers aren't inflated by 1000x